### PR TITLE
Set correct line numbers for tags inside jade-interpolation

### DIFF
--- a/index.js
+++ b/index.js
@@ -297,6 +297,7 @@ Lexer.prototype = {
       this.tokens.push(this.tok('text', prefix + value.substr(0, indexOfStart)));
       this.tokens.push(this.tok('start-jade-interpolation'));
       var child = new this.constructor(value.substr(indexOfStart + 2), this.filename, true);
+      child.lineno = this.lineno;
       var interpolated = child.getTokens();
       for (var i = 0; i < interpolated.length; i++) {
         this.tokens.push(interpolated[i]);

--- a/test/cases/inline-tag.expected.json
+++ b/test/cases/inline-tag.expected.json
@@ -13,8 +13,8 @@
 {"type":"newline","line":5}
 {"type":"text","line":5,"val":""}
 {"type":"start-jade-interpolation","line":5}
-{"type":"tag","line":1,"val":"strong","selfClosing":false}
-{"type":"text","line":1,"val":"foo"}
+{"type":"tag","line":5,"val":"strong","selfClosing":false}
+{"type":"text","line":5,"val":"foo"}
 {"type":"end-jade-interpolation","line":5}
 {"type":"text","line":5,"val":""}
 {"type":"newline","line":6}
@@ -29,8 +29,8 @@
 {"type":"newline","line":10}
 {"type":"text","line":10,"val":""}
 {"type":"start-jade-interpolation","line":10}
-{"type":"tag","line":1,"val":"strong","selfClosing":false}
-{"type":"text","line":1,"val":"foo"}
+{"type":"tag","line":10,"val":"strong","selfClosing":false}
+{"type":"text","line":10,"val":"foo"}
 {"type":"end-jade-interpolation","line":10}
 {"type":"text","line":10,"val":""}
 {"type":"newline","line":11}
@@ -43,8 +43,8 @@
 {"type":"newline","line":15}
 {"type":"text","line":15,"val":"#["}
 {"type":"start-jade-interpolation","line":15}
-{"type":"tag","line":1,"val":"strong","selfClosing":false}
-{"type":"text","line":1,"val":"escaped"}
+{"type":"tag","line":15,"val":"strong","selfClosing":false}
+{"type":"text","line":15,"val":"escaped"}
 {"type":"end-jade-interpolation","line":15}
 {"type":"text","line":15,"val":""}
 {"type":"end-pipeless-text","line":15}

--- a/test/cases/intepolated-elements.expected.json
+++ b/test/cases/intepolated-elements.expected.json
@@ -11,19 +11,19 @@
 {"type":"tag","line":2,"val":"p","selfClosing":false}
 {"type":"text","line":2,"val":"Some text "}
 {"type":"start-jade-interpolation","line":2}
-{"type":"tag","line":1,"val":"a","selfClosing":false}
-{"type":"class","line":1,"val":"rho"}
-{"type":"attrs","line":1,"attrs":[{"name":"href","val":"'#'","escaped":true},{"name":"class","val":"'rho--modifier'","escaped":true}]}
+{"type":"tag","line":2,"val":"a","selfClosing":false}
+{"type":"class","line":2,"val":"rho"}
+{"type":"attrs","line":2,"attrs":[{"name":"href","val":"'#'","escaped":true},{"name":"class","val":"'rho--modifier'","escaped":true}]}
 {"type":"end-jade-interpolation","line":2}
 {"type":"text","line":2,"val":""}
 {"type":"newline","line":3}
 {"type":"tag","line":3,"val":"p","selfClosing":false}
 {"type":"text","line":3,"val":"Some text "}
 {"type":"start-jade-interpolation","line":3}
-{"type":"tag","line":1,"val":"a","selfClosing":false}
-{"type":"class","line":1,"val":"rho"}
-{"type":"attrs","line":1,"attrs":[{"name":"href","val":"'#'","escaped":true},{"name":"class","val":"'rho--modifier'","escaped":true}]}
-{"type":"text","line":1,"val":"with inline link"}
+{"type":"tag","line":3,"val":"a","selfClosing":false}
+{"type":"class","line":3,"val":"rho"}
+{"type":"attrs","line":3,"attrs":[{"name":"href","val":"'#'","escaped":true},{"name":"class","val":"'rho--modifier'","escaped":true}]}
+{"type":"text","line":3,"val":"with inline link"}
 {"type":"end-jade-interpolation","line":3}
 {"type":"text","line":3,"val":""}
 {"type":"eos","line":3}


### PR DESCRIPTION
Currently all interpolated tags return with a line number of 1, so I've set the line number for the child elements based on the parent's line number.

Closes https://github.com/jadejs/jade-parser/issues/4
