### PR TITLE
Add support for for multiline attributes using tabs and commas

### DIFF
--- a/index.js
+++ b/index.js
@@ -751,9 +751,9 @@ Lexer.prototype = {
         if (key.trim() === '') return false;
         if (i === str.length) return true;
         if (loc === 'key') {
-          if (str[i] === ' ' || str[i] === '\n') {
+          if (str[i] === ' ' || str[i] === '\n' || str[i] === '\t') {
             for (var x = i; x < str.length; x++) {
-              if (str[x] != ' ' && str[x] != '\n') {
+              if (str[x] != ' ' && str[x] != '\n' && str[x] != '\t') {
                 if (str[x] === '=' || str[x] === '!' || str[x] === ',') return false;
                 else return true;
               }
@@ -763,9 +763,9 @@ Lexer.prototype = {
         } else if (loc === 'value' && !state.isNesting()) {
           try {
             self.assertExpression(val);
-            if (str[i] === ' ' || str[i] === '\n') {
+            if (str[i] === ' ' || str[i] === '\n' || str[i] === '\t') {
               for (var x = i; x < str.length; x++) {
-                if (str[x] != ' ' && str[x] != '\n') {
+                if (str[x] != ' ' && str[x] != '\n' && str[x] != '\t') {
                   if (characterParser.isPunctuator(str[x]) && str[x] != '"' && str[x] != "'") return false;
                   else return true;
                 }
@@ -799,8 +799,8 @@ Lexer.prototype = {
             case 'key-char':
               if (str[i] === quote) {
                 loc = 'key';
-                if (i + 1 < str.length && [' ', ',', '!', '=', '\n'].indexOf(str[i + 1]) === -1)
-                  this.error('INVALID_KEY_CHARACTER', 'Unexpected character ' + str[i + 1] + ' expected ` `, `\\n`, `,`, `!` or `=`');
+                if (i + 1 < str.length && [' ', ',', '!', '=', '\n', '\t'].indexOf(str[i + 1]) === -1)
+                  this.error('INVALID_KEY_CHARACTER', 'Unexpected character ' + str[i + 1] + ' expected ` `, `\\n`, `\t`, `,`, `!` or `=`');
               } else {
                 key += str[i];
               }

--- a/test/cases/attrs.expected.json
+++ b/test/cases/attrs.expected.json
@@ -72,9 +72,21 @@
 {"type":"tag","line":23,"val":"foo","selfClosing":false}
 {"type":"attrs","line":23,"attrs":[{"name":"date","val":"new Date(0)","escaped":true}]}
 {"type":"newline","line":25}
-{"type":"code","line":25,"val":"var attrs = {foo: 'bar', bar: '<baz>'}","escape":false,"buffer":false}
+{"type":"tag","line":25,"val":"foo","selfClosing":false}
+{"type":"attrs","line":25,"attrs":[{"name":"abc","val":true,"escaped":true},{"name":"def","val":true,"escaped":false}]}
 {"type":"newline","line":27}
-{"type":"tag","line":27,"val":"div","selfClosing":false}
-{"type":"&attributes","line":27,"val":"attrs"}
-{"type":"newline","line":28}
-{"type":"eos","line":28}
+{"type":"tag","line":27,"val":"foo","selfClosing":false}
+{"type":"attrs","line":27,"attrs":[{"name":"abc","val":true,"escaped":true},{"name":"def","val":true,"escaped":false}]}
+{"type":"newline","line":29}
+{"type":"tag","line":29,"val":"foo","selfClosing":false}
+{"type":"attrs","line":29,"attrs":[{"name":"abc","val":true,"escaped":true},{"name":"def","val":true,"escaped":false}]}
+{"type":"newline","line":31}
+{"type":"tag","line":31,"val":"foo","selfClosing":false}
+{"type":"attrs","line":31,"attrs":[{"name":"abc","val":true,"escaped":true},{"name":"def","val":true,"escaped":false}]}
+{"type":"newline","line":34}
+{"type":"code","line":34,"val":"var attrs = {foo: 'bar', bar: '<baz>'}","escape":false,"buffer":false}
+{"type":"newline","line":36}
+{"type":"tag","line":36,"val":"div","selfClosing":false}
+{"type":"&attributes","line":36,"val":"attrs"}
+{"type":"newline","line":37}
+{"type":"eos","line":37}

--- a/test/cases/attrs.jade
+++ b/test/cases/attrs.jade
@@ -22,6 +22,15 @@ input(pattern='\\S+')
 foo(terse="true")
 foo(date=new Date(0))
 
+foo(abc
+   ,def)
+foo(abc,
+    def)
+foo(abc,
+		def)
+foo(abc
+		,def)
+
 - var attrs = {foo: 'bar', bar: '<baz>'}
 
 div&attributes(attrs)


### PR DESCRIPTION
Fixes jadejs/jade#1800. Test case from jadejs/jade#2047.
