### PR TITLE
Remove support for `- each` and `- else`

### DIFF
--- a/index.js
+++ b/index.js
@@ -669,7 +669,7 @@ Lexer.prototype = {
 
   each: function() {
     var captures;
-    if (captures = /^(?:- *)?(?:each|for) +([a-zA-Z_$][\w$]*)(?: *, *([a-zA-Z_$][\w$]*))? * in *([^\n]+)/.exec(this.input)) {
+    if (captures = /^(?:each|for) +([a-zA-Z_$][\w$]*)(?: *, *([a-zA-Z_$][\w$]*))? * in *([^\n]+)/.exec(this.input)) {
       this.consume(captures[0].length);
       var tok = this.tok('each', captures[1]);
       tok.key = captures[2];

--- a/test/cases/each.else.expected.json
+++ b/test/cases/each.else.expected.json
@@ -62,34 +62,21 @@
 {"type":"text","line":34,"val":"user has no details!"}
 {"type":"outdent","line":36}
 {"type":"outdent","line":36}
-{"type":"tag","line":36,"val":"ul","selfClosing":false}
-{"type":"indent","line":37,"val":2}
-{"type":"each","line":37,"val":"prop","key":"key","code":"user"}
-{"type":"indent","line":38,"val":4}
-{"type":"tag","line":38,"val":"li","selfClosing":false}
-{"type":"text","line":38,"val":"#{key}: #{val}"}
-{"type":"outdent","line":39}
-{"type":"code","line":39,"val":"else","escape":false,"buffer":false}
-{"type":"indent","line":40,"val":4}
-{"type":"tag","line":40,"val":"li","selfClosing":false}
-{"type":"text","line":40,"val":"user has no details!"}
+{"type":"code","line":36,"val":"var user = Object.create(null)","escape":false,"buffer":false}
+{"type":"newline","line":37}
+{"type":"code","line":37,"val":"user.name = 'tobi'","escape":false,"buffer":false}
+{"type":"newline","line":39}
+{"type":"tag","line":39,"val":"ul","selfClosing":false}
+{"type":"indent","line":40,"val":2}
+{"type":"each","line":40,"val":"val","key":"key","code":"user"}
+{"type":"indent","line":41,"val":4}
+{"type":"tag","line":41,"val":"li","selfClosing":false}
+{"type":"text","line":41,"val":"#{key}: #{val}"}
 {"type":"outdent","line":42}
-{"type":"outdent","line":42}
-{"type":"code","line":42,"val":"var user = Object.create(null)","escape":false,"buffer":false}
-{"type":"newline","line":43}
-{"type":"code","line":43,"val":"user.name = 'tobi'","escape":false,"buffer":false}
-{"type":"newline","line":45}
-{"type":"tag","line":45,"val":"ul","selfClosing":false}
-{"type":"indent","line":46,"val":2}
-{"type":"each","line":46,"val":"val","key":"key","code":"user"}
-{"type":"indent","line":47,"val":4}
-{"type":"tag","line":47,"val":"li","selfClosing":false}
-{"type":"text","line":47,"val":"#{key}: #{val}"}
-{"type":"outdent","line":48}
-{"type":"else","line":48,"val":""}
-{"type":"indent","line":49,"val":4}
-{"type":"tag","line":49,"val":"li","selfClosing":false}
-{"type":"text","line":49,"val":"user has no details!"}
-{"type":"outdent","line":50}
-{"type":"outdent","line":50}
-{"type":"eos","line":50}
+{"type":"else","line":42,"val":""}
+{"type":"indent","line":43,"val":4}
+{"type":"tag","line":43,"val":"li","selfClosing":false}
+{"type":"text","line":43,"val":"user has no details!"}
+{"type":"outdent","line":44}
+{"type":"outdent","line":44}
+{"type":"eos","line":44}

--- a/test/cases/each.else.jade
+++ b/test/cases/each.else.jade
@@ -33,12 +33,6 @@ ul
   else
     li user has no details!
 
-ul
-  - each prop, key in user
-    li #{key}: #{val}
-  - else
-    li user has no details!
-
 - var user = Object.create(null)
 - user.name = 'tobi'
 


### PR DESCRIPTION
These syntaxes were undocumented and difficult to maintain.

See jadejs/jade-parser#11.
