### PR TITLE
Some extra interpolation improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,12 +144,10 @@ Lexer.prototype = {
     var end = ({'(': ')', '{': '}', '[': ']'})[start];
     var range;
     try {
-      range = characterParser.parseMax(this.input, {start: skip + 1});
+      range = characterParser.parseMaxBracket(this.input, end, {start: skip + 1});
     } catch (ex) {
       this.error('BRACKET_MISMATCH', ex.message);
     }
-    this.assert(this.input[range.end] === end,
-           'start character "' + start + '" should match end character "' + this.input[range.end] + '"');
     return range;
   },
 

--- a/test/errors/interpolated-call.jade
+++ b/test/errors/interpolated-call.jade
@@ -1,0 +1,5 @@
+mixin a
+  p hey
+
+- var myMixin = 'a'
++#{myMixin]}

--- a/test/errors/interpolated-call.json
+++ b/test/errors/interpolated-call.json
@@ -1,0 +1,5 @@
+{
+  "msg": "Syntax Error",
+  "code": "JADE:SYNTAX_ERROR",
+  "line": 5
+}


### PR DESCRIPTION
For 

``` jade
mixin a
  p hey

- var myMixin = 'a'
+#{myMixin]}
```

Previous error message was:

``` js
{ msg: 'start character "{" should match end character "]"',
  code: 'JADE:ASSERT_FAILED',
  line: 5 }
```

It was inaccurate since there is a "}" in that line.

Current error message:

``` js
{ msg: 'Syntax Error',
  code: 'JADE:SYNTAX_ERROR',
  line: 5 }
```
