### PR TITLE
Disallow colon at start or end of attributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -817,6 +817,9 @@ Lexer.prototype = {
         if (isEndOfAttribute(i)) {
           val = val.trim();
           if (val) this.assertExpression(val)
+          if (key[0] === ':' || key[key.length - 1] === ':') {
+            this.error('COLON_ATTRIBUTE', '":" is not valid as the start or end of an un-quoted attribute.');
+          }
           key = key.trim();
           key = key.replace(/^['"]|['"]$/g, '');
           tok.attrs.push({

--- a/test/errors/colon-attribute-2.jade
+++ b/test/errors/colon-attribute-2.jade
@@ -1,0 +1,1 @@
+option(value="level1", class: selected)

--- a/test/errors/colon-attribute-2.json
+++ b/test/errors/colon-attribute-2.json
@@ -1,0 +1,5 @@
+{
+  "msg": "\":\" is not valid as the start or end of an un-quoted attribute.",
+  "code": "JADE:COLON_ATTRIBUTE",
+  "line": 1
+}

--- a/test/errors/colon-attribute-3.jade
+++ b/test/errors/colon-attribute-3.jade
@@ -1,0 +1,1 @@
+option(value="level1", class :selected)

--- a/test/errors/colon-attribute-3.json
+++ b/test/errors/colon-attribute-3.json
@@ -1,0 +1,5 @@
+{
+  "msg": "\":\" is not valid as the start or end of an un-quoted attribute.",
+  "code": "JADE:COLON_ATTRIBUTE",
+  "line": 1
+}

--- a/test/errors/colon-attribute.jade
+++ b/test/errors/colon-attribute.jade
@@ -1,0 +1,1 @@
+option(value="level1", class : selected)

--- a/test/errors/colon-attribute.json
+++ b/test/errors/colon-attribute.json
@@ -1,0 +1,5 @@
+{
+  "msg": "\":\" is not valid as the start or end of an un-quoted attribute.",
+  "code": "JADE:COLON_ATTRIBUTE",
+  "line": 1
+}


### PR DESCRIPTION
(jadejs/jade#1673 adapted to jade-lexer)
### Original description

[closes jadejs/jade#1182]

This prevents things like:

``` jade
option(value="level1", class: selected)
```

from compiling, but if you really wanted the old behavior, you just have to quote the attribute:

``` jade
option(value="level1", "class:" selected)
```

``` html
<option value="level1" class:="class:" selected="selected">Level One</option>
```

This is a breaking change, so part of the 2.0.0 track.
