### PR TITLE
Output separate tokens for code interpolation & Remove support for attribute interpolation

### DIFF
--- a/index.js
+++ b/index.js
@@ -780,15 +780,6 @@ Lexer.prototype = {
 
       var quote = '';
       var self = this;
-      var interpolate = function (attr) {
-        return attr.replace(/(\\)?#\{(.+)/g, function(_, escape, expr){
-          if (escape) return _;
-          var range = characterParser.parseMax(expr);
-          if (expr[range.end] !== '}') return _.substr(0, 2) + interpolate(_.substr(2));
-          self.assertExpression(range.src)
-          return quote + " + (" + range.src + ") + " + quote + interpolate(expr.substr(range.end + 1));
-        });
-      }
 
       this.consume(index + 1);
       tok.attrs = [];
@@ -796,7 +787,6 @@ Lexer.prototype = {
       var escapedAttr = true
       var key = '';
       var val = '';
-      var interpolatable = '';
       var state = characterParser.defaultState();
       var loc = 'key';
       var isEndOfAttribute = function (i) {
@@ -876,17 +866,14 @@ Lexer.prototype = {
               if (state.isString()) {
                 loc = 'string';
                 quote = str[i];
-                interpolatable = str[i];
-              } else {
-                val += str[i];
               }
+              val += str[i];
               break;
             case 'string':
               state = characterParser.parseChar(str[i], state);
-              interpolatable += str[i];
+              val += str[i];
               if (!state.isString()) {
                 loc = 'value';
-                val += interpolate(interpolatable);
               }
               break;
           }

--- a/test/cases/attrs.interpolation.expected.json
+++ b/test/cases/attrs.interpolation.expected.json
@@ -1,8 +1,0 @@
-{"type":"code","line":1,"val":"var id = 5","escape":false,"buffer":false}
-{"type":"newline","line":2}
-{"type":"tag","line":2,"val":"a","selfClosing":false}
-{"type":"attrs","line":2,"attrs":[{"name":"href","val":"'/user/' + (id) + ''","escaped":true}]}
-{"type":"newline","line":3}
-{"type":"tag","line":3,"val":"foo","selfClosing":false}
-{"type":"attrs","line":3,"attrs":[{"name":"bar","val":"'stuff \\#{here} yup'","escaped":true}]}
-{"type":"eos","line":3}

--- a/test/cases/attrs.interpolation.jade
+++ b/test/cases/attrs.interpolation.jade
@@ -1,3 +1,0 @@
-- var id = 5
-a(href='/user/#{id}')
-foo(bar='stuff \#{here} yup')

--- a/test/cases/case-blocks.expected.json
+++ b/test/cases/case-blocks.expected.json
@@ -19,7 +19,9 @@
 {"type":"default","line":9}
 {"type":"indent","line":10,"val":8}
 {"type":"tag","line":10,"val":"p","selfClosing":false}
-{"type":"text","line":10,"val":"you have #{friends} friends"}
+{"type":"text","line":10,"val":"you have "}
+{"type":"interpolated-code","line":10,"val":"friends","escape":true,"buffer":true}
+{"type":"text","line":10,"val":" friends"}
 {"type":"outdent","line":10}
 {"type":"outdent","line":10}
 {"type":"outdent","line":10}

--- a/test/cases/case.expected.json
+++ b/test/cases/case.expected.json
@@ -19,7 +19,9 @@
 {"type":"default","line":7}
 {"type":":","line":7}
 {"type":"tag","line":7,"val":"p","selfClosing":false}
-{"type":"text","line":7,"val":"you have #{friends} friends"}
+{"type":"text","line":7,"val":"you have "}
+{"type":"interpolated-code","line":7,"val":"friends","escape":true,"buffer":true}
+{"type":"text","line":7,"val":" friends"}
 {"type":"outdent","line":8}
 {"type":"code","line":8,"val":"var friends = 0","escape":false,"buffer":false}
 {"type":"newline","line":9}
@@ -35,7 +37,9 @@
 {"type":"default","line":13}
 {"type":"indent","line":14,"val":8}
 {"type":"tag","line":14,"val":"p","selfClosing":false}
-{"type":"text","line":14,"val":"you have #{friends} friends"}
+{"type":"text","line":14,"val":"you have "}
+{"type":"interpolated-code","line":14,"val":"friends","escape":true,"buffer":true}
+{"type":"text","line":14,"val":" friends"}
 {"type":"outdent","line":14}
 {"type":"outdent","line":14}
 {"type":"outdent","line":14}

--- a/test/cases/code.iteration.expected.json
+++ b/test/cases/code.iteration.expected.json
@@ -17,7 +17,7 @@
 {"type":"each","line":12,"val":"item","key":"i","code":"items"}
 {"type":"indent","line":13,"val":4}
 {"type":"tag","line":13,"val":"li","selfClosing":false}
-{"type":"attrs","line":13,"attrs":[{"name":"class","val":"'item-' + (i) + ''","escaped":true}]}
+{"type":"attrs","line":13,"attrs":[{"name":"class","val":"'item-' + i","escaped":true}]}
 {"type":"code","line":13,"val":"item","escape":true,"buffer":true}
 {"type":"outdent","line":15}
 {"type":"outdent","line":15}
@@ -64,6 +64,6 @@
 {"type":"indent","line":35,"val":4}
 {"type":"tag","line":35,"val":"li","selfClosing":false}
 {"type":"interpolated-code","line":35,"val":"n","escape":true,"buffer":true}
-{"type":"outdent","line":35}
-{"type":"outdent","line":35}
-{"type":"eos","line":35}
+{"type":"outdent","line":36}
+{"type":"outdent","line":36}
+{"type":"eos","line":36}

--- a/test/cases/code.iteration.expected.json
+++ b/test/cases/code.iteration.expected.json
@@ -48,7 +48,9 @@
 {"type":"each","line":28,"val":"n","code":"nums"}
 {"type":"indent","line":29,"val":6}
 {"type":"tag","line":29,"val":"li","selfClosing":false}
-{"type":"text","line":29,"val":"#{n}: #{l}"}
+{"type":"interpolated-code","line":29,"val":"n","escape":true,"buffer":true}
+{"type":"text","line":29,"val":": "}
+{"type":"interpolated-code","line":29,"val":"l","escape":true,"buffer":true}
 {"type":"outdent","line":31}
 {"type":"outdent","line":31}
 {"type":"outdent","line":31}
@@ -61,7 +63,7 @@
 {"type":"each","line":34,"val":"n","code":"counter()"}
 {"type":"indent","line":35,"val":4}
 {"type":"tag","line":35,"val":"li","selfClosing":false}
-{"type":"text","line":35,"val":"#{n}"}
+{"type":"interpolated-code","line":35,"val":"n","escape":true,"buffer":true}
 {"type":"outdent","line":35}
 {"type":"outdent","line":35}
 {"type":"eos","line":35}

--- a/test/cases/code.iteration.jade
+++ b/test/cases/code.iteration.jade
@@ -10,7 +10,7 @@ ul
 
 ul
   for item, i in items
-    li(class='item-#{i}')= item
+    li(class='item-' + i)= item
 
 ul
   each item, i in items

--- a/test/cases/each.else.expected.json
+++ b/test/cases/each.else.expected.json
@@ -39,7 +39,9 @@
 {"type":"each","line":23,"val":"val","key":"key","code":"user"}
 {"type":"indent","line":24,"val":4}
 {"type":"tag","line":24,"val":"li","selfClosing":false}
-{"type":"text","line":24,"val":"#{key}: #{val}"}
+{"type":"interpolated-code","line":24,"val":"key","escape":true,"buffer":true}
+{"type":"text","line":24,"val":": "}
+{"type":"interpolated-code","line":24,"val":"val","escape":true,"buffer":true}
 {"type":"outdent","line":25}
 {"type":"else","line":25,"val":""}
 {"type":"indent","line":26,"val":4}
@@ -54,7 +56,9 @@
 {"type":"each","line":31,"val":"prop","key":"key","code":"user"}
 {"type":"indent","line":32,"val":4}
 {"type":"tag","line":32,"val":"li","selfClosing":false}
-{"type":"text","line":32,"val":"#{key}: #{val}"}
+{"type":"interpolated-code","line":32,"val":"key","escape":true,"buffer":true}
+{"type":"text","line":32,"val":": "}
+{"type":"interpolated-code","line":32,"val":"val","escape":true,"buffer":true}
 {"type":"outdent","line":33}
 {"type":"else","line":33,"val":""}
 {"type":"indent","line":34,"val":4}
@@ -71,7 +75,9 @@
 {"type":"each","line":40,"val":"val","key":"key","code":"user"}
 {"type":"indent","line":41,"val":4}
 {"type":"tag","line":41,"val":"li","selfClosing":false}
-{"type":"text","line":41,"val":"#{key}: #{val}"}
+{"type":"interpolated-code","line":41,"val":"key","escape":true,"buffer":true}
+{"type":"text","line":41,"val":": "}
+{"type":"interpolated-code","line":41,"val":"val","escape":true,"buffer":true}
 {"type":"outdent","line":42}
 {"type":"else","line":42,"val":""}
 {"type":"indent","line":43,"val":4}

--- a/test/cases/escape-test.expected.json
+++ b/test/cases/escape-test.expected.json
@@ -13,7 +13,7 @@
 {"type":"indent","line":7,"val":12}
 {"type":"code","line":7,"val":"var txt = '<param name=\"flashvars\" value=\"a=&quot;value_a&quot;&b=&quot;value_b&quot;&c=3\"/>'","escape":false,"buffer":false}
 {"type":"newline","line":8}
-{"type":"text","line":8,"val":"#{txt}"}
+{"type":"interpolated-code","line":8,"val":"txt","escape":true,"buffer":true}
 {"type":"outdent","line":9}
 {"type":"outdent","line":9}
 {"type":"outdent","line":9}

--- a/test/cases/interpolation.escape.expected.json
+++ b/test/cases/interpolation.escape.expected.json
@@ -9,6 +9,7 @@
 {"type":"newline","line":6}
 {"type":"text","line":6,"val":"here"}
 {"type":"newline","line":7}
-{"type":"text","line":7,"val":"My ID #{\"is {\" + id + \"}\"}"}
+{"type":"text","line":7,"val":"My ID "}
+{"type":"interpolated-code","line":7,"val":"\"is {\" + id + \"}\"","escape":true,"buffer":true}
 {"type":"outdent","line":7}
 {"type":"eos","line":7}

--- a/test/cases/regression.784.expected.json
+++ b/test/cases/regression.784.expected.json
@@ -1,5 +1,5 @@
 {"type":"code","line":1,"val":"var url = 'http://www.google.com'","escape":false,"buffer":false}
 {"type":"newline","line":2}
 {"type":"class","line":2,"val":"url"}
-{"type":"text","line":2,"val":"#{url.replace('http://', '').replace(/^www\\./, '')}"}
+{"type":"interpolated-code","line":2,"val":"url.replace('http://', '').replace(/^www\\./, '')","escape":true,"buffer":true}
 {"type":"eos","line":2}


### PR DESCRIPTION
Previously, text that contains interpolated code was not parsed, but rather left for jade-code-gen to handle. With the Jade AST in mind, this is confusing since Text nodes may contain Code.

A separate token type is needed since `code` tokens are of a different nature: `code` tokens need to be indented one more level from the tag while `interpolated-code` tokens are inlined and can be adjacent to text.

Fixes jadejs/jade#2095.
