### PR TITLE
Do not output empty text tokens before start-pipeless-text

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ function Lexer(str, filename, options) {
   this.indentStack = [0];
   this.indentRe = null;
   this.pipeless = false;
+  this.startedPipeless = false;
   // If #{} or !{} syntax is allowed when adding text
   this.interpolationAllowed = true;
 
@@ -204,7 +205,7 @@ Lexer.prototype = {
     if (captures = /^\n[ \t]*\n/.exec(this.input)) {
       this.consume(captures[0].length - 1);
       ++this.lineno;
-      if (this.pipeless) this.tokens.push(this.tok('text', ''));
+      if (this.startedPipeless) this.tokens.push(this.tok('text', ''));
       return true;
     }
   },
@@ -976,6 +977,7 @@ Lexer.prototype = {
     indents = indents || captures && captures[1].length;
     if (indents > this.indentStack[0]) {
       this.tokens.push(this.tok('start-pipeless-text'));
+      this.startedPipeless = true;
       var tokens = [];
       var isMatch;
       // Index in this.input. Can't use this.consume because we might need to
@@ -1007,6 +1009,7 @@ Lexer.prototype = {
         if (i !== 0) this.tokens.push(this.tok('newline'));
         this.addText(token);
       }.bind(this));
+      this.startedPipeless = false;
       this.tokens.push(this.tok('end-pipeless-text'));
       return true;
     }

--- a/test/cases/blocks-in-if.expected.json
+++ b/test/cases/blocks-in-if.expected.json
@@ -1,5 +1,4 @@
 {"type":"comment","line":1,"val":" see https://github.com/jadejs/jade/issues/1589","buffer":false}
-{"type":"text","line":2,"val":""}
 {"type":"newline","line":3}
 {"type":"code","line":3,"val":"var ajax = true","escape":false,"buffer":false}
 {"type":"newline","line":5}

--- a/test/cases/comments.source.expected.json
+++ b/test/cases/comments.source.expected.json
@@ -6,7 +6,6 @@
 {"type":"end-pipeless-text","line":3}
 {"type":"newline","line":4}
 {"type":"comment","line":4,"val":" test/cases/comments.source.jade","buffer":false}
-{"type":"text","line":5,"val":""}
 {"type":"newline","line":6}
 {"type":"comment","line":6,"val":"","buffer":false}
 {"type":"start-pipeless-text","line":6}

--- a/test/cases/mixin-via-include.expected.json
+++ b/test/cases/mixin-via-include.expected.json
@@ -1,5 +1,4 @@
 {"type":"comment","line":1,"val":" regression test for https://github.com/jadejs/jade/issues/1435","buffer":false}
-{"type":"text","line":2,"val":""}
 {"type":"newline","line":3}
 {"type":"include","line":3,"val":"../fixtures/mixin-include.jade"}
 {"type":"newline","line":5}

--- a/test/cases/text.expected.json
+++ b/test/cases/text.expected.json
@@ -6,7 +6,6 @@
 {"type":"newline","line":5}
 {"type":"tag","line":5,"val":"p","selfClosing":false}
 {"type":"dot","line":5}
-{"type":"text","line":6,"val":""}
 {"type":"newline","line":7}
 {"type":"tag","line":7,"val":"p","selfClosing":false}
 {"type":"indent","line":8,"val":2}
@@ -33,7 +32,6 @@
 {"type":"end-pipeless-text","line":18}
 {"type":"newline","line":19}
 {"type":"dot","line":19}
-{"type":"text","line":20,"val":""}
 {"type":"newline","line":21}
 {"type":"dot","line":21}
 {"type":"start-pipeless-text","line":21}


### PR DESCRIPTION
Fixes

``` jade
.

  J
```
