### PR TITLE
Don't accept `include` or `extends` as a tag name

### DIFF
--- a/index.js
+++ b/index.js
@@ -439,6 +439,9 @@ Lexer.prototype = {
       }
       return true;
     }
+    if (this.scan(/^extends?\b/)) {
+      this.error('MALFORMED_EXTENDS', 'malformed extends');
+    }
   },
 
   /**
@@ -541,6 +544,9 @@ Lexer.prototype = {
         }
       }
       return true;
+    }
+    if (this.scan(/^include\b/)) {
+      this.error('MALFORMED_INCLUDE', 'malformed include');
     }
   },
 

--- a/test/errors/malformed-extend.jade
+++ b/test/errors/malformed-extend.jade
@@ -1,0 +1,1 @@
+extend(data-foo='bar') I'm pretending to be a tag

--- a/test/errors/malformed-extend.json
+++ b/test/errors/malformed-extend.json
@@ -1,0 +1,5 @@
+{
+  "msg": "malformed extends",
+  "code": "JADE:MALFORMED_EXTENDS",
+  "line": 1
+}

--- a/test/errors/malformed-include.jade
+++ b/test/errors/malformed-include.jade
@@ -1,0 +1,1 @@
+include(data-foo='bar') I'm pretending to be a tag

--- a/test/errors/malformed-include.json
+++ b/test/errors/malformed-include.json
@@ -1,0 +1,5 @@
+{
+  "msg": "malformed include",
+  "code": "JADE:MALFORMED_INCLUDE",
+  "line": 1
+}


### PR DESCRIPTION
We've been making this change for all the other keywords.  It will make it a lot safer if we ever want to extend the behaviour of keywords in a non-breaking way.
