### PR TITLE
Add .jade extensions to all include/extends test cases

### DIFF
--- a/test/cases/include-extends-from-root.expected.json
+++ b/test/cases/include-extends-from-root.expected.json
@@ -1,3 +1,4 @@
 {"type":"include","line":1,"col":1}
-{"type":"path","line":1,"col":9,"val":"/auxiliary/extends-from-root"}
-{"type":"eos","line":1,"col":37}
+{"type":"path","line":1,"col":9,"val":"/auxiliary/extends-from-root.jade"}
+{"type":"newline","line":2,"col":1}
+{"type":"eos","line":2,"col":1}

--- a/test/cases/include-extends-from-root.jade
+++ b/test/cases/include-extends-from-root.jade
@@ -1,1 +1,1 @@
-include /auxiliary/extends-from-root
+include /auxiliary/extends-from-root.jade

--- a/test/cases/include-extends-of-common-template.expected.json
+++ b/test/cases/include-extends-of-common-template.expected.json
@@ -1,7 +1,7 @@
 {"type":"include","line":1,"col":1}
-{"type":"path","line":1,"col":9,"val":"auxiliary/extends-empty-block-1"}
+{"type":"path","line":1,"col":9,"val":"auxiliary/extends-empty-block-1.jade"}
 {"type":"newline","line":2,"col":1}
 {"type":"include","line":2,"col":1}
-{"type":"path","line":2,"col":9,"val":"auxiliary/extends-empty-block-2"}
+{"type":"path","line":2,"col":9,"val":"auxiliary/extends-empty-block-2.jade"}
 {"type":"newline","line":3,"col":1}
 {"type":"eos","line":3,"col":1}

--- a/test/cases/include-extends-of-common-template.jade
+++ b/test/cases/include-extends-of-common-template.jade
@@ -1,2 +1,2 @@
-include auxiliary/extends-empty-block-1
-include auxiliary/extends-empty-block-2
+include auxiliary/extends-empty-block-1.jade
+include auxiliary/extends-empty-block-2.jade

--- a/test/cases/include-only-text.expected.json
+++ b/test/cases/include-only-text.expected.json
@@ -5,7 +5,7 @@
 {"type":"tag","line":3,"col":5,"val":"p"}
 {"type":"indent","line":4,"col":1,"val":6}
 {"type":"include","line":4,"col":7}
-{"type":"path","line":4,"col":15,"val":"include-only-text-body"}
+{"type":"path","line":4,"col":15,"val":"include-only-text-body.jade"}
 {"type":"indent","line":5,"col":1,"val":8}
 {"type":"tag","line":5,"col":9,"val":"em"}
 {"type":"text","line":5,"col":12,"val":"hello world"}

--- a/test/cases/include-only-text.jade
+++ b/test/cases/include-only-text.jade
@@ -1,5 +1,5 @@
 html
   body
     p
-      include include-only-text-body
+      include include-only-text-body.jade
         em hello world

--- a/test/cases/include-with-text.expected.json
+++ b/test/cases/include-with-text.expected.json
@@ -1,7 +1,7 @@
 {"type":"tag","line":1,"col":1,"val":"html"}
 {"type":"indent","line":2,"col":1,"val":2}
 {"type":"include","line":2,"col":3}
-{"type":"path","line":2,"col":11,"val":"include-with-text-head"}
+{"type":"path","line":2,"col":11,"val":"include-with-text-head.jade"}
 {"type":"indent","line":3,"col":1,"val":4}
 {"type":"tag","line":3,"col":5,"val":"script"}
 {"type":"start-attributes","line":3,"col":11}

--- a/test/cases/include-with-text.jade
+++ b/test/cases/include-with-text.jade
@@ -1,4 +1,4 @@
 html
-  include include-with-text-head
+  include include-with-text-head.jade
     script(src='/caustic.js')
     script(src='/app.js')

--- a/test/cases/include.script.expected.json
+++ b/test/cases/include.script.expected.json
@@ -5,6 +5,6 @@
 {"type":"end-attributes","line":1,"col":43}
 {"type":"indent","line":2,"col":1,"val":2}
 {"type":"include","line":2,"col":3}
-{"type":"path","line":2,"col":11,"val":"auxiliary/pet"}
-{"type":"outdent","line":2,"col":24}
-{"type":"eos","line":2,"col":24}
+{"type":"path","line":2,"col":11,"val":"auxiliary/pet.jade"}
+{"type":"outdent","line":3,"col":1}
+{"type":"eos","line":3,"col":1}

--- a/test/cases/include.script.jade
+++ b/test/cases/include.script.jade
@@ -1,2 +1,2 @@
 script#pet-template(type='text/x-template')
-  include auxiliary/pet
+  include auxiliary/pet.jade

--- a/test/cases/include.yield.nested.expected.json
+++ b/test/cases/include.yield.nested.expected.json
@@ -1,11 +1,11 @@
 {"type":"newline","line":2,"col":1}
 {"type":"include","line":2,"col":1}
-{"type":"path","line":2,"col":9,"val":"auxiliary/yield-nested"}
+{"type":"path","line":2,"col":9,"val":"auxiliary/yield-nested.jade"}
 {"type":"indent","line":3,"col":1,"val":2}
 {"type":"tag","line":3,"col":3,"val":"p"}
 {"type":"text","line":3,"col":5,"val":"some content"}
 {"type":"newline","line":4,"col":1}
 {"type":"tag","line":4,"col":3,"val":"p"}
 {"type":"text","line":4,"col":5,"val":"and some more"}
-{"type":"outdent","line":4,"col":18}
-{"type":"eos","line":4,"col":18}
+{"type":"outdent","line":5,"col":1}
+{"type":"eos","line":5,"col":1}

--- a/test/cases/include.yield.nested.jade
+++ b/test/cases/include.yield.nested.jade
@@ -1,4 +1,4 @@
 
-include auxiliary/yield-nested
+include auxiliary/yield-nested.jade
   p some content
   p and some more

--- a/test/cases/includes.expected.json
+++ b/test/cases/includes.expected.json
@@ -1,6 +1,6 @@
 {"type":"newline","line":2,"col":1}
 {"type":"include","line":2,"col":1}
-{"type":"path","line":2,"col":9,"val":"auxiliary/mixins"}
+{"type":"path","line":2,"col":9,"val":"auxiliary/mixins.jade"}
 {"type":"newline","line":4,"col":1}
 {"type":"call","line":4,"col":1,"val":"foo","args":null}
 {"type":"newline","line":6,"col":1}

--- a/test/cases/includes.jade
+++ b/test/cases/includes.jade
@@ -1,5 +1,5 @@
 
-include auxiliary/mixins
+include auxiliary/mixins.jade
 
 +foo
 

--- a/test/cases/inheritance.alert-dialog.expected.json
+++ b/test/cases/inheritance.alert-dialog.expected.json
@@ -1,6 +1,6 @@
 {"type":"newline","line":2,"col":1}
 {"type":"extends","line":2,"col":1}
-{"type":"path","line":2,"col":9,"val":"auxiliary/dialog"}
+{"type":"path","line":2,"col":9,"val":"auxiliary/dialog.jade"}
 {"type":"newline","line":4,"col":1}
 {"type":"block","line":4,"col":1,"val":"content","mode":"replace"}
 {"type":"indent","line":5,"col":1,"val":2}
@@ -9,5 +9,5 @@
 {"type":"newline","line":6,"col":1}
 {"type":"tag","line":6,"col":3,"val":"p"}
 {"type":"text","line":6,"col":5,"val":"I'm an alert!"}
-{"type":"outdent","line":6,"col":18}
-{"type":"eos","line":6,"col":18}
+{"type":"outdent","line":7,"col":1}
+{"type":"eos","line":7,"col":1}

--- a/test/cases/inheritance.alert-dialog.jade
+++ b/test/cases/inheritance.alert-dialog.jade
@@ -1,5 +1,5 @@
 
-extends auxiliary/dialog
+extends auxiliary/dialog.jade
 
 block content
   h1 Alert!

--- a/test/cases/inheritance.expected.json
+++ b/test/cases/inheritance.expected.json
@@ -1,6 +1,6 @@
 {"type":"newline","line":2,"col":1}
 {"type":"extends","line":2,"col":1}
-{"type":"path","line":2,"col":9,"val":"auxiliary/layout"}
+{"type":"path","line":2,"col":9,"val":"auxiliary/layout.jade"}
 {"type":"newline","line":4,"col":1}
 {"type":"block","line":4,"col":1,"val":"head","mode":"replace"}
 {"type":"indent","line":5,"col":1,"val":2}
@@ -16,5 +16,5 @@
 {"type":"newline","line":9,"col":1}
 {"type":"tag","line":9,"col":3,"val":"p"}
 {"type":"text","line":9,"col":5,"val":"Some content"}
-{"type":"outdent","line":9,"col":17}
-{"type":"eos","line":9,"col":17}
+{"type":"outdent","line":10,"col":1}
+{"type":"eos","line":10,"col":1}

--- a/test/cases/inheritance.extend.expected.json
+++ b/test/cases/inheritance.extend.expected.json
@@ -1,6 +1,6 @@
 {"type":"newline","line":2,"col":1}
 {"type":"extends","line":2,"col":1}
-{"type":"path","line":2,"col":8,"val":"auxiliary/layout"}
+{"type":"path","line":2,"col":8,"val":"auxiliary/layout.jade"}
 {"type":"newline","line":4,"col":1}
 {"type":"block","line":4,"col":1,"val":"head","mode":"replace"}
 {"type":"indent","line":5,"col":1,"val":2}
@@ -16,5 +16,5 @@
 {"type":"newline","line":9,"col":1}
 {"type":"tag","line":9,"col":3,"val":"p"}
 {"type":"text","line":9,"col":5,"val":"Some content"}
-{"type":"outdent","line":9,"col":17}
-{"type":"eos","line":9,"col":17}
+{"type":"outdent","line":10,"col":1}
+{"type":"eos","line":10,"col":1}

--- a/test/cases/inheritance.extend.jade
+++ b/test/cases/inheritance.extend.jade
@@ -1,5 +1,5 @@
 
-extend auxiliary/layout
+extend auxiliary/layout.jade
 
 block head
   script(src='jquery.js')

--- a/test/cases/inheritance.extend.mixins.expected.json
+++ b/test/cases/inheritance.extend.mixins.expected.json
@@ -1,6 +1,6 @@
 {"type":"newline","line":2,"col":1}
 {"type":"extends","line":2,"col":1}
-{"type":"path","line":2,"col":8,"val":"auxiliary/layout"}
+{"type":"path","line":2,"col":8,"val":"auxiliary/layout.jade"}
 {"type":"newline","line":4,"col":1}
 {"type":"mixin","line":4,"col":1,"val":"article","args":"title"}
 {"type":"indent","line":5,"col":1,"val":2}
@@ -17,6 +17,6 @@
 {"type":"indent","line":11,"col":1,"val":4}
 {"type":"tag","line":11,"col":5,"val":"p"}
 {"type":"text","line":11,"col":7,"val":"Foo bar baz!"}
-{"type":"outdent","line":11,"col":19}
-{"type":"outdent","line":11,"col":19}
-{"type":"eos","line":11,"col":19}
+{"type":"outdent","line":12,"col":3}
+{"type":"outdent","line":12,"col":1}
+{"type":"eos","line":12,"col":1}

--- a/test/cases/inheritance.extend.mixins.jade
+++ b/test/cases/inheritance.extend.mixins.jade
@@ -1,5 +1,5 @@
 
-extend auxiliary/layout
+extend auxiliary/layout.jade
 
 mixin article(title)
   if title

--- a/test/cases/inheritance.extend.whitespace.expected.json
+++ b/test/cases/inheritance.extend.whitespace.expected.json
@@ -1,6 +1,6 @@
 {"type":"newline","line":2,"col":1}
 {"type":"extends","line":2,"col":1}
-{"type":"path","line":2,"col":8,"val":"auxiliary/layout"}
+{"type":"path","line":2,"col":8,"val":"auxiliary/layout.jade"}
 {"type":"newline","line":4,"col":1}
 {"type":"block","line":4,"col":1,"val":"head","mode":"replace"}
 {"type":"indent","line":6,"col":1,"val":2}
@@ -16,5 +16,5 @@
 {"type":"newline","line":13,"col":1}
 {"type":"tag","line":13,"col":3,"val":"p"}
 {"type":"text","line":13,"col":5,"val":"Some content"}
-{"type":"outdent","line":13,"col":17}
-{"type":"eos","line":13,"col":17}
+{"type":"outdent","line":14,"col":1}
+{"type":"eos","line":14,"col":1}

--- a/test/cases/inheritance.extend.whitespace.jade
+++ b/test/cases/inheritance.extend.whitespace.jade
@@ -1,5 +1,5 @@
 
-extend auxiliary/layout
+extend auxiliary/layout.jade
 
 block head
 

--- a/test/cases/inheritance.jade
+++ b/test/cases/inheritance.jade
@@ -1,5 +1,5 @@
 
-extends auxiliary/layout
+extends auxiliary/layout.jade
 
 block head
   script(src='jquery.js')

--- a/test/cases/layout.append.expected.json
+++ b/test/cases/layout.append.expected.json
@@ -1,6 +1,6 @@
 {"type":"newline","line":2,"col":1}
 {"type":"extends","line":2,"col":1}
-{"type":"path","line":2,"col":9,"val":"../fixtures/append/app-layout"}
+{"type":"path","line":2,"col":9,"val":"../fixtures/append/app-layout.jade"}
 {"type":"newline","line":4,"col":1}
 {"type":"block","line":4,"col":1,"val":"head","mode":"append"}
 {"type":"indent","line":5,"col":1,"val":2}

--- a/test/cases/layout.append.jade
+++ b/test/cases/layout.append.jade
@@ -1,5 +1,5 @@
 
-extends ../fixtures/append/app-layout
+extends ../fixtures/append/app-layout.jade
 
 block append head
   script(src='foo.js')

--- a/test/cases/layout.append.without-block.expected.json
+++ b/test/cases/layout.append.without-block.expected.json
@@ -1,6 +1,6 @@
 {"type":"newline","line":2,"col":1}
 {"type":"extends","line":2,"col":1}
-{"type":"path","line":2,"col":9,"val":"../fixtures/append-without-block/app-layout"}
+{"type":"path","line":2,"col":9,"val":"../fixtures/append-without-block/app-layout.jade"}
 {"type":"newline","line":4,"col":1}
 {"type":"block","line":4,"col":1,"val":"head","mode":"append"}
 {"type":"indent","line":5,"col":1,"val":2}

--- a/test/cases/layout.append.without-block.jade
+++ b/test/cases/layout.append.without-block.jade
@@ -1,5 +1,5 @@
 
-extends ../fixtures/append-without-block/app-layout
+extends ../fixtures/append-without-block/app-layout.jade
 
 append head
   script(src='foo.js')

--- a/test/cases/layout.multi.append.prepend.block.expected.json
+++ b/test/cases/layout.multi.append.prepend.block.expected.json
@@ -1,5 +1,5 @@
 {"type":"extends","line":1,"col":1}
-{"type":"path","line":1,"col":9,"val":"../fixtures/multi-append-prepend-block/redefine"}
+{"type":"path","line":1,"col":9,"val":"../fixtures/multi-append-prepend-block/redefine.jade"}
 {"type":"newline","line":3,"col":1}
 {"type":"block","line":3,"col":1,"val":"content","mode":"append"}
 {"type":"indent","line":4,"col":1,"val":1}

--- a/test/cases/layout.multi.append.prepend.block.jade
+++ b/test/cases/layout.multi.append.prepend.block.jade
@@ -1,4 +1,4 @@
-extends ../fixtures/multi-append-prepend-block/redefine
+extends ../fixtures/multi-append-prepend-block/redefine.jade
 
 append content
 	p.first.append Something appended to content

--- a/test/cases/layout.prepend.expected.json
+++ b/test/cases/layout.prepend.expected.json
@@ -1,6 +1,6 @@
 {"type":"newline","line":2,"col":1}
 {"type":"extends","line":2,"col":1}
-{"type":"path","line":2,"col":9,"val":"../fixtures/prepend/app-layout"}
+{"type":"path","line":2,"col":9,"val":"../fixtures/prepend/app-layout.jade"}
 {"type":"newline","line":4,"col":1}
 {"type":"block","line":4,"col":1,"val":"head","mode":"prepend"}
 {"type":"indent","line":5,"col":1,"val":2}

--- a/test/cases/layout.prepend.jade
+++ b/test/cases/layout.prepend.jade
@@ -1,5 +1,5 @@
 
-extends ../fixtures/prepend/app-layout
+extends ../fixtures/prepend/app-layout.jade
 
 block prepend head
   script(src='foo.js')

--- a/test/cases/layout.prepend.without-block.expected.json
+++ b/test/cases/layout.prepend.without-block.expected.json
@@ -1,6 +1,6 @@
 {"type":"newline","line":2,"col":1}
 {"type":"extends","line":2,"col":1}
-{"type":"path","line":2,"col":9,"val":"../fixtures/prepend-without-block/app-layout"}
+{"type":"path","line":2,"col":9,"val":"../fixtures/prepend-without-block/app-layout.jade"}
 {"type":"newline","line":4,"col":1}
 {"type":"block","line":4,"col":1,"val":"head","mode":"prepend"}
 {"type":"indent","line":5,"col":1,"val":2}

--- a/test/cases/layout.prepend.without-block.jade
+++ b/test/cases/layout.prepend.without-block.jade
@@ -1,5 +1,5 @@
 
-extends ../fixtures/prepend-without-block/app-layout
+extends ../fixtures/prepend-without-block/app-layout.jade
 
 prepend head
   script(src='foo.js')

--- a/test/cases/yield-before-conditional.expected.json
+++ b/test/cases/yield-before-conditional.expected.json
@@ -3,7 +3,7 @@
 {"type":"tag","line":2,"col":3,"val":"body"}
 {"type":"indent","line":3,"col":1,"val":4}
 {"type":"include","line":3,"col":5}
-{"type":"path","line":3,"col":13,"val":"yield-before-conditional-head"}
+{"type":"path","line":3,"col":13,"val":"yield-before-conditional-head.jade"}
 {"type":"indent","line":4,"col":1,"val":6}
 {"type":"tag","line":4,"col":7,"val":"script"}
 {"type":"start-attributes","line":4,"col":13}

--- a/test/cases/yield-before-conditional.jade
+++ b/test/cases/yield-before-conditional.jade
@@ -1,5 +1,5 @@
 html
   body
-    include yield-before-conditional-head
+    include yield-before-conditional-head.jade
       script(src='/caustic.js')
       script(src='/app.js')

--- a/test/cases/yield-title.expected.json
+++ b/test/cases/yield-title.expected.json
@@ -3,10 +3,10 @@
 {"type":"tag","line":2,"col":3,"val":"body"}
 {"type":"indent","line":3,"col":1,"val":4}
 {"type":"include","line":3,"col":5}
-{"type":"path","line":3,"col":13,"val":"yield-title-head"}
+{"type":"path","line":3,"col":13,"val":"yield-title-head.jade"}
 {"type":"indent","line":4,"col":1,"val":6}
 {"type":"text","line":4,"col":9,"val":"My Title"}
-{"type":"outdent","line":4,"col":17}
-{"type":"outdent","line":4,"col":17}
-{"type":"outdent","line":4,"col":17}
-{"type":"eos","line":4,"col":17}
+{"type":"outdent","line":5,"col":5}
+{"type":"outdent","line":5,"col":3}
+{"type":"outdent","line":5,"col":1}
+{"type":"eos","line":5,"col":1}

--- a/test/cases/yield-title.jade
+++ b/test/cases/yield-title.jade
@@ -1,4 +1,4 @@
 html
   body
-    include yield-title-head
+    include yield-title-head.jade
       | My Title

--- a/test/cases/yield.expected.json
+++ b/test/cases/yield.expected.json
@@ -3,7 +3,7 @@
 {"type":"tag","line":2,"col":3,"val":"body"}
 {"type":"indent","line":3,"col":1,"val":4}
 {"type":"include","line":3,"col":5}
-{"type":"path","line":3,"col":13,"val":"yield-head"}
+{"type":"path","line":3,"col":13,"val":"yield-head.jade"}
 {"type":"indent","line":4,"col":1,"val":6}
 {"type":"tag","line":4,"col":7,"val":"script"}
 {"type":"start-attributes","line":4,"col":13}

--- a/test/cases/yield.jade
+++ b/test/cases/yield.jade
@@ -1,5 +1,5 @@
 html
   body
-    include yield-head
+    include yield-head.jade
       script(src='/caustic.js')
       script(src='/app.js')


### PR DESCRIPTION
In preparation of removing support for automatically adding `.jade`.
