### PR TITLE
Use is-expression module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var assert = require('assert');
-var acorn = require('acorn');
+var isExpression = require('is-expression');
 var characterParser = require('character-parser');
 var error = require('jade-error');
 
@@ -59,15 +59,8 @@ Lexer.prototype = {
   assertExpression: function (exp, noThrow) {
     //this verifies that a JavaScript expression is valid
     try {
-      var parser = new acorn.Parser({ecmaVersion: 6}, exp, 0);
-      parser.nextToken();
-      parser.parseExpression();
-      if (parser.type !== acorn.tokTypes.eof) {
-        parser.unexpected();
-      }
+      return isExpression(exp, {throw: !noThrow});
     } catch (ex) {
-      if (noThrow) return false;
-
       // not coming from acorn
       if (!ex.loc) throw ex;
 
@@ -76,7 +69,6 @@ Lexer.prototype = {
       var msg = 'Syntax Error: ' + ex.message.replace(/ \([0-9]+:[0-9]+\)$/, '');
       this.error('SYNTAX_ERROR', msg);
     }
-    if (noThrow) return true;
   },
 
   assertNestingCorrect: function (exp) {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "The jade lexer (takes a string and converts it to an array of tokens)",
   "keywords": [],
   "dependencies": {
-    "acorn": "^2.5.2",
     "character-parser": "^2.1.1",
+    "is-expression": "^1.0.0",
     "jade-error": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Practically, this disallows line comments in buffered code, preventing hard-to-debug bugs.

Before:

```
SyntaxError: Unexpected token (2:94)
    at Parser.pp.raise (/home/timothy_gu/jade-code-gen/node_modules/with/node_modules/acorn-globals/node_modules/acorn/dist/acorn.js:937:13)
    at Parser.pp.unexpected (/home/timothy_gu/jade-code-gen/node_modules/with/node_modules/acorn-globals/node_modules/acorn/dist/acorn.js:1493:8)
    at Parser.pp.expect (/home/timothy_gu/jade-code-gen/node_modules/with/node_modules/acorn-globals/node_modules/acorn/dist/acorn.js:1487:26)
    at Parser.pp.parseParenExpression (/home/timothy_gu/jade-code-gen/node_modules/with/node_modules/acorn-globals/node_modules/acorn/dist/acorn.js:343:8)
```

After:

```
Error: Jade:1:8
  > 1| = asfd // asd
--------------^

Syntax Error: Line comments not allowed in an expression
    at makeError (/home/timothy_gu/jade-error/index.js:32:13)
    at Lexer.error (/home/timothy_gu/jade-lexer/index.js:51:15)
    at Lexer.assertExpression (/home/timothy_gu/jade-lexer/index.js:70:12)
    at Lexer.code (/home/timothy_gu/jade-lexer/index.js:919:28)
    at Lexer.advance (/home/timothy_gu/jade-lexer/index.js:1285:15)
    at Lexer.getTokens (/home/timothy_gu/jade-lexer/index.js:1308:12)
    at lex (/home/timothy_gu/jade-lexer/index.js:12:42)
```
