### PR TITLE
Support tag::filter

### DIFF
--- a/index.js
+++ b/index.js
@@ -329,7 +329,7 @@ Lexer.prototype = {
   tag: function() {
     var captures;
 
-    if (captures = /^(\w(?:[-:\w]*\w)?)/.exec(this.input)) {
+    if (captures = /^(\w(?:(?:[-\w]+:?)*\w)?)/.exec(this.input)) {
       var tok, name = captures[1], len = captures[0].length;
       this.consume(len);
       tok = this.tok('tag', name);
@@ -1243,7 +1243,7 @@ Lexer.prototype = {
    */
 
   colon: function() {
-    var tok = this.scan(/^: +/, ':');
+    var tok = this.scan(/^: +/, ':') || this.scan(/^:(?=:)/, ':');
     if (tok) {
       this.tokens.push(tok);
       return true;

--- a/test/cases/filters.inline-block.expected.json
+++ b/test/cases/filters.inline-block.expected.json
@@ -1,0 +1,11 @@
+{"type":"tag","line":1,"col":1,"val":"p"}
+{"type":":","line":1,"col":2}
+{"type":"filter","line":1,"col":4,"val":"markdown-it"}
+{"type":"text","line":1,"col":17,"val":"**bolded**"}
+{"type":"newline","line":2,"col":1}
+{"type":"tag","line":2,"col":1,"val":"p"}
+{"type":":","line":2,"col":2}
+{"type":"filter","line":2,"col":3,"val":"markdown-it"}
+{"type":"text","line":2,"col":16,"val":"**bolded**"}
+{"type":"newline","line":3,"col":1}
+{"type":"eos","line":3,"col":1}

--- a/test/cases/filters.inline-block.pug
+++ b/test/cases/filters.inline-block.pug
@@ -1,0 +1,2 @@
+p: :markdown-it **bolded**
+p::markdown-it **bolded**


### PR DESCRIPTION
This breaks compatibility.

The commit contains three parts:
1. add test case
2. allow the first colon in `::filter` to be recognized as a `:` token
3. disallow two consecutive colons in tag names

Number 3 makes this commit incompatible.

Fixes pugjs/jade#758.
