### PR TITLE
Fix column number of invalid attribute expression error

### DIFF
--- a/test/errors/attribute-invalid-expression.json
+++ b/test/errors/attribute-invalid-expression.json
@@ -1,0 +1,6 @@
+{
+  "msg": "Syntax Error: Unterminated string constant",
+  "code": "PUG:SYNTAX_ERROR",
+  "line": 2,
+  "column": 5
+}

--- a/test/errors/attribute-invalid-expression.pug
+++ b/test/errors/attribute-invalid-expression.pug
@@ -1,0 +1,3 @@
+a(href=
+    'asfd
+   asfd')

--- a/test/update-test-cases.js
+++ b/test/update-test-cases.js
@@ -15,7 +15,7 @@ fs.readdirSync(dir).forEach(function (testCase) {
       if (ex.code !== 'ENOENT') throw ex;
       expected = null;
     }
-    var result = lex(fs.readFileSync(dir + testCase, 'utf8'), __dirname + '/cases/' + testCase);
+    var result = lex(fs.readFileSync(dir + testCase, 'utf8'), {filename: __dirname + '/cases/' + testCase});
     try {
       assert.deepEqual(expected, result);
     } catch (ex) {
@@ -38,7 +38,7 @@ fs.readdirSync(edir).forEach(function (testCase) {
     }
     var actual;
     try {
-      lex(fs.readFileSync(edir + testCase, 'utf8'), edir + testCase);
+      lex(fs.readFileSync(edir + testCase, 'utf8'), {filename: edir + testCase});
       throw new Error('Expected ' + testCase + ' to throw an exception.');
     } catch (ex) {
       if (!ex || !ex.code || !ex.code.indexOf('PUG:') === 0) throw ex;


### PR DESCRIPTION
See test case. Currently it looks like

```
Error: Pug:1:-5
  > 1| a(href=
-^
    2|      'asdf
    3|  ')

Syntax Error: Unterminated string constant
```
