### PR TITLE
allow unquoted use of Angular 2's `[(bananabox)]="val"` syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -1014,6 +1014,7 @@ Lexer.prototype = {
 
       var whitespaceRe = /[ \n\t]/;
       var quoteRe = /['"]/;
+      var ng2Re = /[([]/;
 
       var escapedAttr = true
       var key = '';
@@ -1060,8 +1061,9 @@ Lexer.prototype = {
             for (var x = i; x < str.length; x++) {
               if (!whitespaceRe.test(str[x])) {
                 // if it is a JavaScript punctuator, then assume that it is
-                // a part of the value
-                return !characterParser.isPunctuator(str[x]) || quoteRe.test(str[x]);
+                // a part of the value, unless it's an Angular2 opening bracket
+                return !characterParser.isPunctuator(str[x]) ||
+                    quoteRe.test(str[x]) || ng2Re.test(str[x]);
               }
             }
           }

--- a/test/cases/ng2.expected.json
+++ b/test/cases/ng2.expected.json
@@ -1,0 +1,8 @@
+{"type":"tag","line":1,"col":1,"val":"div"}
+{"type":"start-attributes","line":1,"col":4}
+{"type":"attribute","line":2,"col":3,"name":"*star","val":"\"*\"","mustEscape":true}
+{"type":"attribute","line":3,"col":3,"name":"(baz)","val":"\"cow\"","mustEscape":true}
+{"type":"attribute","line":4,"col":3,"name":"[box]","val":"\"box\"","mustEscape":true}
+{"type":"end-attributes","line":5,"col":1}
+{"type":"newline","line":6,"col":1}
+{"type":"eos","line":6,"col":1}

--- a/test/cases/ng2.pug
+++ b/test/cases/ng2.pug
@@ -1,0 +1,5 @@
+div(
+  *star="*"
+  (baz)="cow"
+  [box]="box"
+)


### PR DESCRIPTION
See [here](https://github.com/pugjs/pug/issues/2270); commas and
enquoting were valid solutions, but this makes it work even without
those. Note that `obj [idx]` would have made for a valid JS value, which
would suddenly be interpreted differently with this commit. The use of
spacing here to me seems no more common than using Angular 2 though --
none of the existing tests broke with this edit. That being said, for
safety perhaps this could be made into an optional setting instead.
