### PR TITLE
Remove restriction on attributes with colons

### DIFF
--- a/index.js
+++ b/index.js
@@ -1082,11 +1082,6 @@ Lexer.prototype = {
 
           val = val.trim();
 
-          if (key[0] === ':') this.incrementColumn(-key.length);
-          else if (key[key.length - 1] === ':') this.incrementColumn(-1);
-          if (key[0] === ':' || key[key.length - 1] === ':') {
-            this.error('COLON_ATTRIBUTE', '":" is not valid as the start or end of an un-quoted attribute.');
-          }
           key = key.trim();
           key = key.replace(/^['"]|['"]$/g, '');
 

--- a/test/errors/colon-attribute-2.json
+++ b/test/errors/colon-attribute-2.json
@@ -1,6 +1,0 @@
-{
-  "msg": "\":\" is not valid as the start or end of an un-quoted attribute.",
-  "code": "PUG:COLON_ATTRIBUTE",
-  "line": 1,
-  "column": 29
-}

--- a/test/errors/colon-attribute-2.pug
+++ b/test/errors/colon-attribute-2.pug
@@ -1,1 +1,0 @@
-option(value="level1", class: selected)

--- a/test/errors/colon-attribute-3.json
+++ b/test/errors/colon-attribute-3.json
@@ -1,6 +1,0 @@
-{
-  "msg": "\":\" is not valid as the start or end of an un-quoted attribute.",
-  "code": "PUG:COLON_ATTRIBUTE",
-  "line": 1,
-  "column": 30
-}

--- a/test/errors/colon-attribute-3.pug
+++ b/test/errors/colon-attribute-3.pug
@@ -1,1 +1,0 @@
-option(value="level1", class :selected)

--- a/test/errors/colon-attribute.json
+++ b/test/errors/colon-attribute.json
@@ -1,6 +1,0 @@
-{
-  "msg": "\":\" is not valid as the start or end of an un-quoted attribute.",
-  "code": "PUG:COLON_ATTRIBUTE",
-  "line": 1,
-  "column": 30
-}

--- a/test/errors/colon-attribute.pug
+++ b/test/errors/colon-attribute.pug
@@ -1,1 +1,0 @@
-option(value="level1", class : selected)


### PR DESCRIPTION
Attributes that start with colons are widely used in frameworks such as Vue.js, and do not pose a special parsing concern.

Fixes pugjs/pug#2454.
Fixes #61.
Fixes decreased user satisfaction rate.
